### PR TITLE
feat: file navigation, review tracking, and diff improvements

### DIFF
--- a/lua/diff-review/actions.lua
+++ b/lua/diff-review/actions.lua
@@ -280,12 +280,16 @@ local function resolve_file_at_cursor()
     return nil, "Cannot navigate to deleted line"
   end
 
-  if line_info.type == "header" then
+  if line_info.type == "hunk" then
     if line_info.new_line then
       line_info.file_line = line_info.new_line
     else
-      return nil, "Cannot navigate from metadata line"
+      return nil, "Cannot navigate from hunk header"
     end
+  end
+
+  if line_info.type == "meta" then
+    return nil, "Cannot navigate from metadata line"
   end
 
   if file.status == "D" then

--- a/lua/diff-review/actions.lua
+++ b/lua/diff-review/actions.lua
@@ -250,106 +250,126 @@ function M.view_all_comments()
   vim.notify(string.format("Found %d comment(s)", #all_comments), vim.log.levels.INFO)
 end
 
--- Open file at cursor with optional split mode
-function M.open_file_at_cursor(split_mode)
+-- Resolve file and line info at the cursor for navigation
+local function resolve_file_at_cursor()
   local diff = require("diff-review.diff")
   local file_list = require("diff-review.file_list")
   local layout = require("diff-review.layout")
   local state = layout.get_state()
 
-  -- Get current file
+  if not state.is_open then
+    return nil, "Review not open"
+  end
+
   local files = file_list.state.files
   local current_index = file_list.state.current_index
 
   if #files == 0 or current_index < 1 or current_index > #files then
-    vim.notify("No file selected", vim.log.levels.WARN)
-    return
+    return nil, "No file selected"
   end
 
   local file = files[current_index]
 
   -- Get line mapping at cursor
   local line_info = diff.get_file_line_at_cursor()
-
   if not line_info then
-    vim.notify("Cannot determine file line at this position", vim.log.levels.WARN)
-    return
+    return nil, "Cannot determine file line at this position"
   end
 
-  -- Handle deleted lines
   if line_info.type == "delete" then
-    vim.notify("Cannot navigate to deleted line", vim.log.levels.INFO)
-    return
+    return nil, "Cannot navigate to deleted line"
   end
 
-  -- Handle header lines - use hunk start
   if line_info.type == "header" then
     if line_info.new_line then
       line_info.file_line = line_info.new_line
     else
-      vim.notify("Cannot navigate from metadata line", vim.log.levels.WARN)
-      return
+      return nil, "Cannot navigate from metadata line"
     end
   end
 
-  -- Handle deleted files
   if file.status == "D" then
-    vim.notify("Cannot open deleted file: " .. file.path, vim.log.levels.INFO)
-    return
+    return nil, "Cannot open deleted file: " .. file.path
   end
 
-  -- Check if file exists
   local filepath = file.path
   if not vim.loop.fs_stat(filepath) then
-    if file.status == "A" then
-      vim.notify("New file not yet created: " .. filepath, vim.log.levels.ERROR)
-    else
-      vim.notify("File not found: " .. filepath, vim.log.levels.ERROR)
-    end
+    return nil, "File not found: " .. filepath
+  end
+
+  return { filepath = filepath, line = line_info.file_line }
+end
+
+-- Open file at cursor in the original tab (keeps review open)
+function M.open_file()
+  local result, err = resolve_file_at_cursor()
+  if not result then
+    vim.notify(err, vim.log.levels.WARN)
     return
   end
 
-  -- Store the original window to return to
-  local original_win = state.original_win
+  local layout = require("diff-review.layout")
+  layout.open_file_in_original_tab(result.filepath, result.line)
+end
 
-  -- Close review UI
-  local ui = require("diff-review.ui")
-  ui.close()
+-- Return to review tab from file view
+function M.return_to_review()
+  local layout = require("diff-review.layout")
+  if not layout.focus_review() then
+    vim.notify("No active review to return to", vim.log.levels.WARN)
+  end
+end
 
-  -- Return to original window if valid
-  if original_win and vim.api.nvim_win_is_valid(original_win) then
-    vim.api.nvim_set_current_win(original_win)
+-- Open file at cursor with split in the original tab
+function M.open_file_split()
+  local result, err = resolve_file_at_cursor()
+  if not result then
+    vim.notify(err, vim.log.levels.WARN)
+    return
   end
 
-  -- Open file with appropriate split mode
-  if split_mode == "split" then
-    vim.cmd("split " .. vim.fn.fnameescape(filepath))
-  elseif split_mode == "vsplit" then
-    vim.cmd("vsplit " .. vim.fn.fnameescape(filepath))
-  else
-    vim.cmd("edit " .. vim.fn.fnameescape(filepath))
+  local layout = require("diff-review.layout")
+  local state = layout.get_state()
+
+  -- Switch to original tab
+  if state.original_tab and vim.api.nvim_tabpage_is_valid(state.original_tab) then
+    vim.api.nvim_set_current_tabpage(state.original_tab)
+  end
+  if state.original_win and vim.api.nvim_win_is_valid(state.original_win) then
+    vim.api.nvim_set_current_win(state.original_win)
   end
 
-  -- Jump to the mapped line and center
-  if line_info.file_line and line_info.file_line > 0 then
-    vim.api.nvim_win_set_cursor(0, { line_info.file_line, 0 })
+  vim.cmd("split " .. vim.fn.fnameescape(result.filepath))
+  if result.line and result.line > 0 then
+    vim.api.nvim_win_set_cursor(0, { result.line, 0 })
     vim.cmd("normal! zz")
   end
 end
 
--- Convenience function: open file in current window
-function M.open_file()
-  M.open_file_at_cursor(nil)
-end
-
--- Convenience function: open file in horizontal split
-function M.open_file_split()
-  M.open_file_at_cursor("split")
-end
-
--- Convenience function: open file in vertical split
+-- Open file at cursor with vsplit in the original tab
 function M.open_file_vsplit()
-  M.open_file_at_cursor("vsplit")
+  local result, err = resolve_file_at_cursor()
+  if not result then
+    vim.notify(err, vim.log.levels.WARN)
+    return
+  end
+
+  local layout = require("diff-review.layout")
+  local state = layout.get_state()
+
+  -- Switch to original tab
+  if state.original_tab and vim.api.nvim_tabpage_is_valid(state.original_tab) then
+    vim.api.nvim_set_current_tabpage(state.original_tab)
+  end
+  if state.original_win and vim.api.nvim_win_is_valid(state.original_win) then
+    vim.api.nvim_set_current_win(state.original_win)
+  end
+
+  vim.cmd("vsplit " .. vim.fn.fnameescape(result.filepath))
+  if result.line and result.line > 0 then
+    vim.api.nvim_win_set_cursor(0, { result.line, 0 })
+    vim.cmd("normal! zz")
+  end
 end
 
 return M

--- a/lua/diff-review/config.lua
+++ b/lua/diff-review/config.lua
@@ -26,6 +26,8 @@ M.defaults = {
     -- Diff pane navigation
     diff_next_file = "<Tab>",
     diff_prev_file = "<S-Tab>",
+    -- Review tracking
+    toggle_reviewed = "x",
     -- File navigation
     open_file = "gf",
     open_file_split = "<C-w>f",

--- a/lua/diff-review/config.lua
+++ b/lua/diff-review/config.lua
@@ -26,6 +26,11 @@ M.defaults = {
     -- Diff pane navigation
     diff_next_file = "<Tab>",
     diff_prev_file = "<S-Tab>",
+    -- File navigation
+    open_file = "gf",
+    open_file_split = "<C-w>f",
+    open_file_vsplit = "<C-w>gf",
+    return_to_review = "gr",
     -- Comment keymaps
     add_comment = "<leader>c",
     edit_comment = "<leader>e",

--- a/lua/diff-review/config.lua
+++ b/lua/diff-review/config.lua
@@ -96,6 +96,7 @@ M.defaults = {
     context_lines = 3,     -- Lines of context around changes
     ignore_whitespace = false,
     syntax_highlighting = true,
+    highlight_blend = 0.60, -- Blend diff backgrounds toward Normal bg (0.0 = full color, 1.0 = invisible)
   },
 
   -- Persistence options

--- a/lua/diff-review/diff.lua
+++ b/lua/diff-review/diff.lua
@@ -21,7 +21,6 @@ function M.statuscolumn()
 
   local w = M._line_num_width
   local pad = string.rep(" ", w)
-  local sep = string.rep("─", w * 2 + 1)
 
   if entry.type == "context" then
     return string.format("%%#LineNr#%" .. w .. "d %" .. w .. "d%%#NonText#│%%*", entry.old_line, entry.new_line)
@@ -29,11 +28,8 @@ function M.statuscolumn()
     return string.format("%%#LineNr#%s %" .. w .. "d%%#NonText#│%%*", pad, entry.new_line)
   elseif entry.type == "delete" then
     return string.format("%%#LineNr#%" .. w .. "d %s%%#NonText#│%%*", entry.old_line, pad)
-  elseif entry.type == "hunk" then
-    return "%#NonText#" .. sep .. "│%*"
   end
 
-  -- File metadata lines: no gutter
   return ""
 end
 

--- a/lua/diff-review/diff.lua
+++ b/lua/diff-review/diff.lua
@@ -596,15 +596,13 @@ local function apply_diff_highlights(buf, line_types)
   -- Apply line highlights for each line
   for i, line_type in ipairs(line_types) do
     if line_type == "add" then
-      -- Green background for added lines
       vim.api.nvim_buf_set_extmark(buf, ns_id, i - 1, 0, {
-        line_hl_group = "DiffAdd",
+        line_hl_group = "DiffReviewAdd",
         priority = 100,
       })
     elseif line_type == "delete" then
-      -- Red background for deleted lines
       vim.api.nvim_buf_set_extmark(buf, ns_id, i - 1, 0, {
-        line_hl_group = "DiffDelete",
+        line_hl_group = "DiffReviewDelete",
         priority = 100,
       })
     end

--- a/lua/diff-review/diff.lua
+++ b/lua/diff-review/diff.lua
@@ -4,6 +4,37 @@ local config = require("diff-review.config")
 
 -- Module-level line mapping cache
 M._line_mapping = nil
+M._line_num_width = 4  -- Width for formatting line numbers
+
+-- Statuscolumn function for diff line numbers
+-- Shows old and new file line numbers instead of buffer line numbers
+function M.statuscolumn()
+  local lnum = vim.v.lnum
+  if not M._line_mapping then
+    return ""
+  end
+
+  local entry = M._line_mapping[lnum]
+  if not entry then
+    return ""
+  end
+
+  local w = M._line_num_width
+  local pad = string.rep(" ", w)
+  local sep = string.rep("─", w * 2 + 1)
+
+  if entry.type == "context" then
+    return string.format("%%#LineNr#%" .. w .. "d %" .. w .. "d%%#NonText#│%%*", entry.old_line, entry.new_line)
+  elseif entry.type == "add" then
+    return string.format("%%#LineNr#%s %" .. w .. "d%%#NonText#│%%*", pad, entry.new_line)
+  elseif entry.type == "delete" then
+    return string.format("%%#LineNr#%" .. w .. "d %s%%#NonText#│%%*", entry.old_line, pad)
+  elseif entry.type == "header" then
+    return "%#NonText#" .. sep .. "│%*"
+  end
+
+  return ""
+end
 
 -- Execute git command and return output
 local function exec_cmd(cmd)
@@ -425,6 +456,18 @@ local function build_line_mapping(diff_output)
     display_line = display_line + 1
   end
 
+  -- Compute max line number for column width
+  local max_line = 0
+  for _, entry in pairs(mapping) do
+    if entry.old_line and entry.old_line > max_line then
+      max_line = entry.old_line
+    end
+    if entry.new_line and entry.new_line > max_line then
+      max_line = entry.new_line
+    end
+  end
+  M._line_num_width = math.max(3, #tostring(max_line))
+
   return mapping
 end
 
@@ -453,6 +496,7 @@ end
 -- Clear line mapping cache
 function M.clear_line_mapping()
   M._line_mapping = nil
+  M._line_num_width = 4
 end
 
 -- Parse diff output into structured format

--- a/lua/diff-review/diff.lua
+++ b/lua/diff-review/diff.lua
@@ -29,10 +29,11 @@ function M.statuscolumn()
     return string.format("%%#LineNr#%s %" .. w .. "d%%#NonText#│%%*", pad, entry.new_line)
   elseif entry.type == "delete" then
     return string.format("%%#LineNr#%" .. w .. "d %s%%#NonText#│%%*", entry.old_line, pad)
-  elseif entry.type == "header" then
+  elseif entry.type == "hunk" then
     return "%#NonText#" .. sep .. "│%*"
   end
 
+  -- File metadata lines: no gutter
   return ""
 end
 
@@ -412,7 +413,7 @@ local function build_line_mapping(diff_output)
       new_file_line = tonumber(new_start)
       old_file_line = tonumber(old_start)
       mapping[display_line] = {
-        type = "header",
+        type = "hunk",
         file_line = nil,
         old_line = old_file_line,
         new_line = new_file_line,
@@ -446,9 +447,9 @@ local function build_line_mapping(diff_output)
         new_file_line = new_file_line + 1
         old_file_line = old_file_line + 1
       else
-        -- Other lines (file headers, etc)
+        -- File metadata lines (diff --git, index, ---, +++)
         mapping[display_line] = {
-          type = "header",
+          type = "meta",
           file_line = nil,
         }
       end

--- a/lua/diff-review/diff.lua
+++ b/lua/diff-review/diff.lua
@@ -5,10 +5,16 @@ local config = require("diff-review.config")
 -- Module-level line mapping cache
 M._line_mapping = nil
 M._line_num_width = 4  -- Width for formatting line numbers
+M._comment_lines = {}  -- Set of line numbers that have comments (for statuscolumn highlighting)
 
 -- Statuscolumn function for diff line numbers
 -- Shows old and new file line numbers instead of buffer line numbers
 function M.statuscolumn()
+  -- Hide line numbers on virtual lines (comment text, etc.)
+  if vim.v.virtnum ~= 0 then
+    return ""
+  end
+
   local lnum = vim.v.lnum
   if not M._line_mapping then
     return ""
@@ -21,13 +27,14 @@ function M.statuscolumn()
 
   local w = M._line_num_width
   local pad = string.rep(" ", w)
+  local hl = M._comment_lines[lnum] and "DiffReviewCommentGutter" or "LineNr"
 
   if entry.type == "context" then
-    return string.format("%%#LineNr#%" .. w .. "d %" .. w .. "d%%#NonText#│%%*", entry.old_line, entry.new_line)
+    return string.format("%%#" .. hl .. "#%" .. w .. "d %" .. w .. "d %%*", entry.old_line, entry.new_line)
   elseif entry.type == "add" then
-    return string.format("%%#LineNr#%s %" .. w .. "d%%#NonText#│%%*", pad, entry.new_line)
+    return string.format("%%#" .. hl .. "#%s %" .. w .. "d %%*", pad, entry.new_line)
   elseif entry.type == "delete" then
-    return string.format("%%#LineNr#%" .. w .. "d %s%%#NonText#│%%*", entry.old_line, pad)
+    return string.format("%%#" .. hl .. "#%" .. w .. "d %s %%*", entry.old_line, pad)
   end
 
   return ""
@@ -400,11 +407,18 @@ local function build_line_mapping(diff_output)
   local display_line = 1
   local new_file_line = 0
   local old_file_line = 0
+  local seen_hunk = false
 
   for line in diff_output:gmatch("[^\r\n]+") do
     -- Match hunk header: @@ -start,count +start,count @@
     local old_start, old_count, new_start, new_count = line:match("^@@ %-(%d+),?(%d*) %+(%d+),?(%d*) @@")
     if old_start then
+      -- Add separator line before hunk headers (except the first)
+      if seen_hunk then
+        mapping[display_line] = { type = "separator", file_line = nil }
+        display_line = display_line + 1
+      end
+      seen_hunk = true
       -- Hunk header line
       new_file_line = tonumber(new_start)
       old_file_line = tonumber(old_start)
@@ -532,7 +546,8 @@ end
 -- Parse diff and extract clean code with line metadata
 local function parse_diff_with_syntax(diff_output)
   local lines = {}
-  local line_types = {} -- "add", "delete", "context", "header"
+  local line_types = {} -- "add", "delete", "context", "header", "separator"
+  local seen_hunk = false
 
   for line in diff_output:gmatch("[^\r\n]+") do
     local prefix = line:sub(1, 1)
@@ -548,8 +563,17 @@ local function parse_diff_with_syntax(diff_output)
       -- Context line - strip the space prefix
       table.insert(lines, line:sub(2))
       table.insert(line_types, "context")
-    elseif line:match("^@@") or line:match("^diff ") or line:match("^index ") then
-      -- Hunk header or diff metadata
+    elseif line:match("^@@") then
+      -- Add blank separator line before hunk headers (except the first)
+      if seen_hunk then
+        table.insert(lines, "")
+        table.insert(line_types, "separator")
+      end
+      seen_hunk = true
+      table.insert(lines, line)
+      table.insert(line_types, "header")
+    elseif line:match("^diff ") or line:match("^index ") then
+      -- Diff metadata
       table.insert(lines, line)
       table.insert(line_types, "header")
     else

--- a/lua/diff-review/export.lua
+++ b/lua/diff-review/export.lua
@@ -15,12 +15,28 @@ M.modes = {
 	DIFF = "diff",
 }
 
+-- Resolve a buffer line to a file line number using the diff line mapping
+local function resolve_file_line(buf_line)
+	local diff = require("diff-review.diff")
+	if not diff._line_mapping then
+		return buf_line
+	end
+	local entry = diff._line_mapping[buf_line]
+	if not entry then
+		return buf_line
+	end
+	return entry.new_line or entry.old_line or buf_line
+end
+
 -- Format comment with line information
 local function format_comment_line(comment)
 	if comment.type == "range" then
-		return string.format("- Lines %d-%d: %s", comment.line_range.start, comment.line_range["end"], comment.text)
+		local start_line = resolve_file_line(comment.line_range.start)
+		local end_line = resolve_file_line(comment.line_range["end"])
+		return string.format("- Lines %d-%d: %s", start_line, end_line, comment.text)
 	else
-		return string.format("- Line %d: %s", comment.line, comment.text)
+		local file_line = resolve_file_line(comment.line)
+		return string.format("- Line %d: %s", file_line, comment.text)
 	end
 end
 
@@ -94,26 +110,34 @@ local function build_diff_line_map(diff_output)
 	local idx = 0
 	local old_line = nil
 	local new_line = nil
+	local seen_hunk = false
 
 	for line in diff_output:gmatch("[^\r\n]+") do
-		idx = idx + 1
-
 		local old_start, new_start = line:match("^@@ %-(%d+),?%d* %+(%d+),?%d* @@")
 		if old_start and new_start then
+			-- Account for separator line before hunks (except the first)
+			if seen_hunk then
+				idx = idx + 1
+			end
+			seen_hunk = true
+			idx = idx + 1
 			old_line = tonumber(old_start)
 			new_line = tonumber(new_start)
-		elseif old_line and new_line then
-			local prefix = line:sub(1, 1)
-			if prefix == "+" then
-				line_map[idx] = new_line
-				new_line = new_line + 1
-			elseif prefix == "-" then
-				line_map[idx] = nil
-				old_line = old_line + 1
-			elseif prefix == " " then
-				line_map[idx] = new_line
-				old_line = old_line + 1
-				new_line = new_line + 1
+		else
+			idx = idx + 1
+			if old_line and new_line then
+				local prefix = line:sub(1, 1)
+				if prefix == "+" then
+					line_map[idx] = new_line
+					new_line = new_line + 1
+				elseif prefix == "-" then
+					line_map[idx] = nil
+					old_line = old_line + 1
+				elseif prefix == " " then
+					line_map[idx] = new_line
+					old_line = old_line + 1
+					new_line = new_line + 1
+				end
 			end
 		end
 	end
@@ -311,7 +335,7 @@ function M.export_full()
 			table.insert(lines, "")
 
 			-- Add comment text
-			table.insert(lines, string.format("💬 %s", comment.text))
+			table.insert(lines, string.format("%s", comment.text))
 			table.insert(lines, "")
 			table.insert(lines, "---")
 			table.insert(lines, "")
@@ -373,11 +397,21 @@ function M.export_annotated_diff()
 			end)
 
 			-- Parse diff and insert comments
+			-- Buffer lines include separator lines before hunks (except the first),
+			-- so track a buffer_line that accounts for those offsets
 			local comment_idx = 1
-			local diff_line_idx = 0
+			local buffer_line = 0
+			local seen_hunk_in_export = false
 
 			for line in diff_output:gmatch("[^\r\n]+") do
-				diff_line_idx = diff_line_idx + 1
+				local is_hunk = line:match("^@@") ~= nil
+				if is_hunk and seen_hunk_in_export then
+					buffer_line = buffer_line + 1 -- separator line
+				end
+				if is_hunk then
+					seen_hunk_in_export = true
+				end
+				buffer_line = buffer_line + 1
 
 				-- Add the diff line
 				table.insert(output_lines, line)
@@ -387,9 +421,9 @@ function M.export_annotated_diff()
 					local comment = file_comments[comment_idx]
 					local comment_line = comment.type == "range" and comment.line_range.start or comment.line
 
-					if diff_line_idx == comment_line then
+					if buffer_line == comment_line then
 						-- Insert comment as a special annotation line
-						table.insert(output_lines, string.format("+    // 💬 %s", comment.text))
+						table.insert(output_lines, string.format("+    // %s", comment.text))
 						comment_idx = comment_idx + 1
 					else
 						break

--- a/lua/diff-review/file_list.lua
+++ b/lua/diff-review/file_list.lua
@@ -158,7 +158,6 @@ local function get_stats_header_lines()
 
   return {
     stats_line,
-    opts.ui.stats_header.separator,
   }
 end
 

--- a/lua/diff-review/file_list.lua
+++ b/lua/diff-review/file_list.lua
@@ -16,6 +16,7 @@ M.state = {
   view_mode = (config.get().file_list and config.get().file_list.view_mode) or "tree",  -- "flat" or "tree"
   tree = nil,  -- Tree structure for tree view
   flat_tree = nil,  -- Flattened tree for rendering
+  reviewed = {},  -- Set of file paths marked as reviewed
 }
 
 -- Timers for debouncing rapid navigation
@@ -148,17 +149,12 @@ local function get_stats_header_lines()
   if total_added > 0 then table.insert(file_parts, string.format("%dA", total_added)) end
   local file_str = table.concat(file_parts, " ")
 
-  -- Get file icon if available
-  local icon_str = ""
-  if opts.ui.show_icons and devicons then
-    local icon = devicons.get_icon("file", "", { default = true })
-    if icon then
-      icon_str = icon .. " "
-    end
-  end
+  -- Get reviewed progress
+  local reviewed, total_files_count = M.get_progress()
+  local progress_str = string.format("%d/%d", reviewed, total_files_count)
 
-  local stats_line = string.format("  %s | %s%s | +%d -%d",
-    review_type, icon_str, file_str, total_additions, total_deletions)
+  local stats_line = string.format("  %s | %s | +%d -%d | %s",
+    review_type, file_str, total_additions, total_deletions, progress_str)
 
   return {
     stats_line,
@@ -205,6 +201,21 @@ local function apply_stats_header_highlights(highlights, lines)
         end_col = end_col,
         hl_group = "DiffDelete",
       })
+    end
+
+    -- Highlight review progress (N/N at end of line)
+    local progress_pos = line:find("%d+/%d+%s*$")
+    if progress_pos then
+      local reviewed_count, total_count = line:match("(%d+)/(%d+)%s*$")
+      if reviewed_count and total_count then
+        local hl = (reviewed_count == total_count) and "DiagnosticOk" or "DiagnosticInfo"
+        table.insert(highlights, {
+          line = line_idx,
+          col = progress_pos - 1,
+          end_col = #line,
+          hl_group = hl,
+        })
+      end
     end
   end
 end
@@ -331,8 +342,13 @@ local function render_tree_view(state, lines, highlights)
       local file = node.file_data
       local status_info = get_status_icons()[file.status] or { icon = "?", hl = "Normal" }
 
+      local is_reviewed = M.state.reviewed[file.path]
+
       -- Selection indicator
       prefix = (index == M.state.current_index) and "> " or "  "
+
+      -- Reviewed indicator
+      local reviewed_part = is_reviewed and "✓ " or ""
 
       -- Get file icon
       local file_icon, icon_color = get_file_icon(file.path)
@@ -357,10 +373,21 @@ local function render_tree_view(state, lines, highlights)
         end
       end
 
-      local line = string.format("%s%s%s %s%s%s%s", prefix, tree_prefix, status_info.icon, icon_part, node.name, stats_part, comment_part)
+      local line = string.format("%s%s%s%s %s%s%s%s", prefix, tree_prefix, reviewed_part, status_info.icon, icon_part, node.name, stats_part, comment_part)
       table.insert(lines, line)
 
       local col = #prefix + #tree_prefix
+
+      -- Highlight reviewed indicator
+      if is_reviewed then
+        table.insert(highlights, {
+          line = #lines - 1,
+          col = col,
+          end_col = col + #reviewed_part,
+          hl_group = "DiagnosticOk",
+        })
+        col = col + #reviewed_part
+      end
 
       -- Highlight status icon
       table.insert(highlights, {
@@ -385,8 +412,18 @@ local function render_tree_view(state, lines, highlights)
         })
       end
 
+      -- Dim reviewed files (apply after icon highlights so it takes precedence on text)
+      if is_reviewed and index ~= M.state.current_index then
+        table.insert(highlights, {
+          line = #lines - 1,
+          col = #prefix + #tree_prefix + #reviewed_part + #status_info.icon + 1,
+          end_col = -1,
+          hl_group = "Comment",
+        })
+      end
+
       -- Highlight stats
-      if stats_part ~= "" then
+      if stats_part ~= "" and not is_reviewed then
         local stats_col = #line - #comment_part - #stats_part
 
         if stats and stats.additions > 0 then
@@ -417,7 +454,7 @@ local function render_tree_view(state, lines, highlights)
       end
 
       -- Highlight comment count
-      if comment_count > 0 then
+      if comment_count > 0 and not is_reviewed then
         local comment_col = #line - #comment_part
         table.insert(highlights, {
           line = #lines - 1,
@@ -489,7 +526,9 @@ function M.render()
 
     for i, file in ipairs(M.state.files) do
       local status_info = get_status_icons()[file.status] or { icon = "?", hl = "Normal" }
+      local is_reviewed = M.state.reviewed[file.path]
       local prefix = (i == M.state.current_index) and "> " or "  "
+      local reviewed_part = is_reviewed and "✓ " or ""
 
       -- Get file icon if available
       local file_icon, icon_color = get_file_icon(file.path)
@@ -515,24 +554,34 @@ function M.render()
         end
       end
 
-      local line = string.format("%s%s %s%s%s%s", prefix, status_info.icon, icon_part, file.path, stats_part, comment_part)
+      local line = string.format("%s%s%s %s%s%s%s", prefix, reviewed_part, status_info.icon, icon_part, file.path, stats_part, comment_part)
       table.insert(lines, line)
 
       local col = #prefix
 
+      -- Highlight reviewed indicator
+      if is_reviewed then
+        table.insert(highlights, {
+          line = #lines - 1,
+          col = col,
+          end_col = col + #reviewed_part,
+          hl_group = "DiagnosticOk",
+        })
+        col = col + #reviewed_part
+      end
+
       -- Highlight status icon
       table.insert(highlights, {
-        line = #lines - 1,  -- 0-indexed
+        line = #lines - 1,
         col = col,
         end_col = col + #status_info.icon,
         hl_group = status_info.hl,
       })
 
-      col = col + #status_info.icon + 1  -- Move past status icon and space
+      col = col + #status_info.icon + 1
 
       -- Highlight file icon if present
       if file_icon then
-        -- Create a dynamic highlight group for the icon color
         if icon_color then
           local hl_group = "DevIcon_" .. file.path:gsub("[^%w]", "_")
           vim.api.nvim_set_hl(0, hl_group, { fg = icon_color })
@@ -546,12 +595,20 @@ function M.render()
         end
       end
 
+      -- Dim reviewed files
+      if is_reviewed and i ~= M.state.current_index then
+        table.insert(highlights, {
+          line = #lines - 1,
+          col = #prefix + #reviewed_part + #status_info.icon + 1,
+          end_col = -1,
+          hl_group = "Comment",
+        })
+      end
+
       -- Highlight stats if present
-      if stats_part ~= "" then
-        -- Find position of stats in the line (before comment part)
+      if stats_part ~= "" and not is_reviewed then
         local stats_col = #line - #comment_part - #stats_part
 
-        -- Highlight additions
         if stats and stats.additions > 0 then
           local add_str = "+" .. tostring(stats.additions)
           local add_pos = line:find("%+" .. tostring(stats.additions), stats_col, true)
@@ -565,7 +622,6 @@ function M.render()
           end
         end
 
-        -- Highlight deletions
         if stats and stats.deletions > 0 then
           local del_str = "-" .. tostring(stats.deletions)
           local del_pos = line:find("%-" .. tostring(stats.deletions), stats_col, true)
@@ -581,7 +637,7 @@ function M.render()
       end
 
       -- Highlight comment count if present
-      if comment_count > 0 then
+      if comment_count > 0 and not is_reviewed then
         local comment_col = #line - #comment_part
         table.insert(highlights, {
           line = #lines - 1,
@@ -904,6 +960,61 @@ end
 
 function M.close_fold()
   set_fold_state(false)
+end
+
+-- Toggle reviewed status for the current file
+function M.toggle_reviewed()
+  if #M.state.files == 0 then
+    return
+  end
+
+  local file = M.state.files[M.state.current_index]
+  if not file then
+    return
+  end
+
+  if M.state.reviewed[file.path] then
+    M.state.reviewed[file.path] = nil
+  else
+    M.state.reviewed[file.path] = true
+  end
+
+  schedule_render()
+
+  -- Trigger auto-save so reviewed state persists
+  local reviews = require("diff-review.reviews")
+  reviews.save_current()
+end
+
+-- Get reviewed file paths as a list (for persistence)
+function M.get_reviewed_files()
+  local files = {}
+  for path, _ in pairs(M.state.reviewed) do
+    table.insert(files, path)
+  end
+  return files
+end
+
+-- Set reviewed files from a list (for persistence)
+function M.set_reviewed_files(files)
+  M.state.reviewed = {}
+  if files then
+    for _, path in ipairs(files) do
+      M.state.reviewed[path] = true
+    end
+  end
+end
+
+-- Get review progress counts
+function M.get_progress()
+  local total = #M.state.files
+  local reviewed = 0
+  for _, file in ipairs(M.state.files) do
+    if M.state.reviewed[file.path] then
+      reviewed = reviewed + 1
+    end
+  end
+  return reviewed, total
 end
 
 return M

--- a/lua/diff-review/github.lua
+++ b/lua/diff-review/github.lua
@@ -85,11 +85,40 @@ function M.get_pr_files(pr_number)
   return data.files, nil
 end
 
+-- Convert a buffer line to its raw diff line index, accounting for
+-- separator lines inserted between hunks in the display buffer.
+local function buffer_to_raw_line(file_diff, buffer_line)
+  local raw_idx = 0
+  local buf_idx = 0
+  local seen_hunk = false
+
+  for line in file_diff:gmatch("[^\r\n]+") do
+    raw_idx = raw_idx + 1
+    if line:match("^@@") then
+      if seen_hunk then
+        buf_idx = buf_idx + 1 -- separator line
+      end
+      seen_hunk = true
+    end
+    buf_idx = buf_idx + 1
+    if buf_idx == buffer_line then
+      return raw_idx
+    end
+  end
+  return nil
+end
+
 function M.get_diff_position(file_diff, buffer_line)
   if not file_diff or buffer_line < 1 then
     return nil
   end
 
+  local raw_line = buffer_to_raw_line(file_diff, buffer_line)
+  if not raw_line then
+    return nil
+  end
+
+  -- Find the first hunk header in raw diff lines
   local idx = 0
   local patch_start = nil
   for line in file_diff:gmatch("[^\r\n]+") do
@@ -99,11 +128,11 @@ function M.get_diff_position(file_diff, buffer_line)
     end
   end
 
-  if not patch_start or buffer_line < patch_start then
+  if not patch_start or raw_line < patch_start then
     return nil
   end
 
-  return buffer_line - patch_start + 1
+  return raw_line - patch_start + 1
 end
 
 function M.format_single_comment(comment, file_diff)
@@ -120,6 +149,11 @@ function M.format_single_comment(comment, file_diff)
 end
 
 local function get_line_info(file_diff, buffer_line)
+  local raw_target = buffer_to_raw_line(file_diff, buffer_line)
+  if not raw_target then
+    return nil
+  end
+
   local idx = 0
   local old_line = nil
   local new_line = nil
@@ -132,7 +166,7 @@ local function get_line_info(file_diff, buffer_line)
       old_line = tonumber(old_start)
       new_line = tonumber(new_start)
     elseif old_line and new_line then
-      if idx == buffer_line then
+      if idx == raw_target then
         local prefix = line:sub(1, 1)
         if prefix == "+" then
           return { side = "RIGHT", line = new_line }

--- a/lua/diff-review/init.lua
+++ b/lua/diff-review/init.lua
@@ -225,6 +225,13 @@ M.setup = function(opts)
     require("diff-review.layout").close()
   end, { desc = "Close diff review window" })
 
+  vim.api.nvim_create_user_command("DiffReviewReturn", function()
+    local layout = require("diff-review.layout")
+    if not layout.focus_review() then
+      vim.notify("No active review to return to", vim.log.levels.INFO)
+    end
+  end, { desc = "Return to diff review from file view" })
+
   vim.api.nvim_create_user_command("DiffReviewCopy", function(opts)
     local args = vim.split(opts.args or "", "%s+", { trimempty = true })
     local export = require("diff-review.export")

--- a/lua/diff-review/layout.lua
+++ b/lua/diff-review/layout.lua
@@ -387,6 +387,7 @@ function M.setup_keymaps()
   vim.keymap.set("n", opts.keymaps.open_directory, require("diff-review.file_list").open_fold, keymap_opts)
   vim.keymap.set("n", opts.keymaps.close_directory, require("diff-review.file_list").close_fold, keymap_opts)
   vim.keymap.set("n", "<leader>t", require("diff-review.file_list").toggle_view_mode, keymap_opts)
+  vim.keymap.set("n", opts.keymaps.toggle_reviewed, require("diff-review.file_list").toggle_reviewed, keymap_opts)
 
   -- Track cursor movement to sync selection
   vim.api.nvim_create_autocmd("CursorMoved", {
@@ -416,9 +417,10 @@ function M.setup_keymaps()
     vim.keymap.set("n", key, "<Nop>", keymap_opts)
   end
 
-  -- File list navigation from diff pane
+  -- File list navigation and review tracking from diff pane
   vim.keymap.set("n", opts.keymaps.diff_next_file, require("diff-review.file_list").next_file, keymap_opts)
   vim.keymap.set("n", opts.keymaps.diff_prev_file, require("diff-review.file_list").prev_file, keymap_opts)
+  vim.keymap.set("n", opts.keymaps.toggle_reviewed, require("diff-review.file_list").toggle_reviewed, keymap_opts)
 
   -- File navigation actions
   vim.keymap.set("n", opts.keymaps.open_file, actions.open_file, keymap_opts)

--- a/lua/diff-review/layout.lua
+++ b/lua/diff-review/layout.lua
@@ -137,8 +137,10 @@ function M.open(review_type, base, head, pr_number, separator)
 
   -- Set window options for diff
   vim.api.nvim_win_set_option(M.state.diff_win, "wrap", false)
-  vim.api.nvim_win_set_option(M.state.diff_win, "number", true)
+  vim.api.nvim_win_set_option(M.state.diff_win, "number", false)
   vim.api.nvim_win_set_option(M.state.diff_win, "relativenumber", false)
+  vim.api.nvim_win_set_option(M.state.diff_win, "statuscolumn",
+    "%!v:lua.require('diff-review.diff').statuscolumn()")
 
   -- Setup keymaps
   M.setup_keymaps()

--- a/lua/diff-review/layout.lua
+++ b/lua/diff-review/layout.lua
@@ -10,6 +10,8 @@ M.state = {
   diff_win = nil,
   diff_buf = nil,
   original_win = nil,
+  original_tab = nil,
+  review_tab = nil,
 }
 
 -- Last review state for restoration
@@ -100,8 +102,9 @@ function M.open(review_type, base, head, pr_number, separator)
   )
   reviews.set_current(review)
 
-  -- Save current window
+  -- Save current window and tab
   M.state.original_win = vim.api.nvim_get_current_win()
+  M.state.original_tab = vim.api.nvim_get_current_tabpage()
 
   -- Create buffers
   M.state.file_list_buf = create_scratch_buffer("DiffReview://file_list")
@@ -112,6 +115,7 @@ function M.open(review_type, base, head, pr_number, separator)
 
   -- Create a new tab
   vim.cmd("tabnew")
+  M.state.review_tab = vim.api.nvim_get_current_tabpage()
   local main_win = vim.api.nvim_get_current_win()
 
   -- Create file list window (left)
@@ -240,6 +244,8 @@ function M.close()
   M.state.diff_win = nil
   M.state.diff_buf = nil
   M.state.original_win = nil
+  M.state.original_tab = nil
+  M.state.review_tab = nil
 end
 
 -- Restore previous review session
@@ -319,6 +325,53 @@ function M.toggle()
   end
 end
 
+-- Focus the review tab (switch to it without closing anything)
+function M.focus_review()
+  if not M.state.is_open then
+    return false
+  end
+
+  if M.state.review_tab and vim.api.nvim_tabpage_is_valid(M.state.review_tab) then
+    vim.api.nvim_set_current_tabpage(M.state.review_tab)
+    -- Focus the diff window if valid
+    if M.state.diff_win and vim.api.nvim_win_is_valid(M.state.diff_win) then
+      vim.api.nvim_set_current_win(M.state.diff_win)
+    end
+    return true
+  end
+
+  return false
+end
+
+-- Open a file in the original tab without closing the review
+-- Returns true if successful
+function M.open_file_in_original_tab(filepath, line_num)
+  if not M.state.is_open then
+    return false
+  end
+
+  -- Switch to the original tab
+  if M.state.original_tab and vim.api.nvim_tabpage_is_valid(M.state.original_tab) then
+    vim.api.nvim_set_current_tabpage(M.state.original_tab)
+  end
+
+  -- If original window is valid, focus it
+  if M.state.original_win and vim.api.nvim_win_is_valid(M.state.original_win) then
+    vim.api.nvim_set_current_win(M.state.original_win)
+  end
+
+  -- Open the file
+  vim.cmd("edit " .. vim.fn.fnameescape(filepath))
+
+  -- Jump to line and center
+  if line_num and line_num > 0 then
+    vim.api.nvim_win_set_cursor(0, { line_num, 0 })
+    vim.cmd("normal! zz")
+  end
+
+  return true
+end
+
 -- Setup keymaps for the windows
 function M.setup_keymaps()
   local opts = config.get()
@@ -368,9 +421,10 @@ function M.setup_keymaps()
   vim.keymap.set("n", opts.keymaps.diff_prev_file, require("diff-review.file_list").prev_file, keymap_opts)
 
   -- File navigation actions
-  vim.keymap.set("n", "gf", actions.open_file, keymap_opts)
-  vim.keymap.set("n", "<C-w>f", actions.open_file_split, keymap_opts)
-  vim.keymap.set("n", "<C-w>gf", actions.open_file_vsplit, keymap_opts)
+  vim.keymap.set("n", opts.keymaps.open_file, actions.open_file, keymap_opts)
+  vim.keymap.set("n", opts.keymaps.open_file_split, actions.open_file_split, keymap_opts)
+  vim.keymap.set("n", opts.keymaps.open_file_vsplit, actions.open_file_vsplit, keymap_opts)
+  vim.keymap.set("n", opts.keymaps.return_to_review, actions.return_to_review, keymap_opts)
 end
 
 -- Get current state

--- a/lua/diff-review/layout.lua
+++ b/lua/diff-review/layout.lua
@@ -415,7 +415,7 @@ function M.setup_keymaps()
   vim.keymap.set("v", opts.keymaps.add_comment, actions.add_comment_for_range, keymap_opts)
 
   -- Block insert mode in diff pane (buffer is read-only)
-  for _, key in ipairs({ "i", "I", "a", "A", "o", "O", "s", "S", "c", "C", "r", "R" }) do
+  for _, key in ipairs({ "i", "I", "a", "A", "o", "O", "s", "S", "r", "R" }) do
     vim.keymap.set("n", key, "<Nop>", keymap_opts)
   end
 

--- a/lua/diff-review/note_mode.lua
+++ b/lua/diff-review/note_mode.lua
@@ -55,6 +55,13 @@ end
 
 -- Set up buffer-local keymaps
 local function setup_buffer_keymaps(bufnr)
+  -- Skip diff review buffers — they have their own comment keymaps
+  local layout = require("diff-review.layout")
+  local state = layout.get_state()
+  if state.is_open and (bufnr == state.diff_buf or bufnr == state.file_list_buf) then
+    return
+  end
+
   local opts = config.get()
   if not opts or not opts.keymaps then
     return -- Config not initialized, skip keymap setup

--- a/lua/diff-review/persistence.lua
+++ b/lua/diff-review/persistence.lua
@@ -32,16 +32,17 @@ local function get_storage_path(context_id)
   return string.format("%s/%s.json", dir, context_id or "default")
 end
 
--- Save comments to JSON
-function M.save(comments, context_id)
+-- Save comments and reviewed files to JSON
+function M.save(comments, context_id, reviewed_files)
   local path = get_storage_path(context_id)
 
   -- Convert comments to JSON-serializable format
   local data = {
-    version = 1,
+    version = 2,
     context_id = context_id or "default",
     saved_at = os.time(),
     comments = comments,
+    reviewed_files = reviewed_files or {},
   }
 
   local json = vim.fn.json_encode(data)
@@ -59,20 +60,21 @@ function M.save(comments, context_id)
   return true
 end
 
--- Load comments from JSON
+-- Load comments and reviewed files from JSON
+-- Returns comments, reviewed_files
 function M.load(context_id)
   local path = get_storage_path(context_id)
 
   -- Check if file exists
   if vim.fn.filereadable(path) == 0 then
-    return nil
+    return nil, nil
   end
 
   -- Read file
   local file = io.open(path, "r")
   if not file then
     vim.notify("Failed to load comments: " .. path, vim.log.levels.ERROR)
-    return nil
+    return nil, nil
   end
 
   local content = file:read("*a")
@@ -82,10 +84,10 @@ function M.load(context_id)
   local ok, data = pcall(vim.fn.json_decode, content)
   if not ok or not data then
     vim.notify("Failed to parse comments file: " .. path, vim.log.levels.ERROR)
-    return nil
+    return nil, nil
   end
 
-  return data.comments
+  return data.comments, data.reviewed_files
 end
 
 -- Delete saved comments
@@ -119,19 +121,21 @@ function M.list_contexts()
   return contexts
 end
 
--- Auto-save comments
-function M.auto_save(comments, context_id)
-  -- Only auto-save if there are comments
-  if #comments == 0 then
+-- Auto-save comments and reviewed files
+function M.auto_save(comments, context_id, reviewed_files)
+  -- Only auto-save if there's data worth saving
+  if #comments == 0 and (not reviewed_files or #reviewed_files == 0) then
     return
   end
 
-  M.save(comments, context_id)
+  M.save(comments, context_id, reviewed_files)
 end
 
--- Auto-load comments
+-- Auto-load comments and reviewed files
+-- Returns comments, reviewed_files
 function M.auto_load(context_id)
-  return M.load(context_id) or {}
+  local comments, reviewed_files = M.load(context_id)
+  return comments or {}, reviewed_files
 end
 
 -- Get storage directory path

--- a/lua/diff-review/reviews.lua
+++ b/lua/diff-review/reviews.lua
@@ -91,8 +91,8 @@ function M.set_current(review)
 
   M.current_review = review
 
-  -- Load comments for this review
-  local loaded_comments = persistence.auto_load(review.id)
+  -- Load comments and reviewed files for this review
+  local loaded_comments, reviewed_files = persistence.auto_load(review.id)
   if loaded_comments and #loaded_comments > 0 then
     comments.comments = loaded_comments
     comments.next_id = 1
@@ -105,6 +105,10 @@ function M.set_current(review)
   else
     comments.clear()
   end
+
+  -- Restore reviewed files
+  local file_list = require("diff-review.file_list")
+  file_list.set_reviewed_files(reviewed_files)
 end
 
 -- Get current review
@@ -112,13 +116,14 @@ function M.get_current()
   return M.current_review
 end
 
--- Save current review comments
+-- Save current review comments and reviewed files
 function M.save_current()
   if not M.current_review then
     return false
   end
 
-  return persistence.auto_save(comments.get_all(), M.current_review.id)
+  local file_list = require("diff-review.file_list")
+  return persistence.auto_save(comments.get_all(), M.current_review.id, file_list.get_reviewed_files())
 end
 
 -- List all reviews

--- a/lua/diff-review/ui.lua
+++ b/lua/diff-review/ui.lua
@@ -133,6 +133,19 @@ local function wrap_line(line, max_width, indent)
   return wrapped
 end
 
+-- Resolve a buffer line to a file line number using the diff line mapping
+local function resolve_file_line(buf_line)
+  local diff = require("diff-review.diff")
+  if not diff._line_mapping then
+    return buf_line
+  end
+  local entry = diff._line_mapping[buf_line]
+  if not entry then
+    return buf_line
+  end
+  return entry.new_line or entry.old_line or buf_line
+end
+
 -- Format comment text for display
 local function format_comment_text(comment)
   local opts = config.get()
@@ -143,9 +156,9 @@ local function format_comment_text(comment)
   -- Add line range header
   local line_info
   if comment.type == "range" and comment.line_range then
-    line_info = string.format("  L%d-L%d", comment.line_range.start, comment.line_range["end"])
+    line_info = string.format("  L%d-L%d", resolve_file_line(comment.line_range.start), resolve_file_line(comment.line_range["end"]))
   else
-    line_info = string.format("  L%d", comment.line)
+    line_info = string.format("  L%d", resolve_file_line(comment.line))
   end
   table.insert(formatted, line_info)
 
@@ -175,7 +188,14 @@ function M.update_comment_display()
     return
   end
 
+  -- Only apply comment line highlights if user configured one,
+  -- otherwise the empty highlight overrides diff add/delete colors
+  local opts = config.get()
+  local has_comment_line_hl = opts.ui.comment_line_hl ~= nil
+
   -- Clear existing comments
+  local diff = require("diff-review.diff")
+  diff._comment_lines = {}
   M.clear_comments(state.diff_buf)
 
   -- Get current file
@@ -252,28 +272,34 @@ function M.update_comment_display()
       table.insert(virtual_by_line[virt_display_line], comment)
     end
 
-    -- If it's a range comment, place signs on all lines in range
+    -- Mark lines for statuscolumn highlighting and place range signs
     if comment.type == "range" and comment.line_range then
       local range_start = math.max(comment.line_range.start, 1)
       local range_end = math.min(comment.line_range["end"], line_count)
 
       for line = range_start, range_end do
+        diff._comment_lines[line] = true
         pcall(vim.fn.sign_place, comment.id * 1000 + line, M.sign_group, sign_name, state.diff_buf, {
           lnum = line,
           priority = 10,
         })
-        pcall(vim.api.nvim_buf_set_extmark, state.diff_buf, M.ns_id, line - 1, 0, {
+        if has_comment_line_hl then
+          pcall(vim.api.nvim_buf_set_extmark, state.diff_buf, M.ns_id, line - 1, 0, {
+            linehl = "DiffReviewCommentLine",
+            hl_mode = "combine",
+            priority = 200,
+          })
+        end
+      end
+    else
+      diff._comment_lines[display_line] = true
+      if has_comment_line_hl then
+        pcall(vim.api.nvim_buf_set_extmark, state.diff_buf, M.ns_id, display_line - 1, 0, {
           linehl = "DiffReviewCommentLine",
           hl_mode = "combine",
           priority = 200,
         })
       end
-    else
-      pcall(vim.api.nvim_buf_set_extmark, state.diff_buf, M.ns_id, display_line - 1, 0, {
-        linehl = "DiffReviewCommentLine",
-        hl_mode = "combine",
-        priority = 200,
-      })
     end
 
     placed_count = placed_count + 1

--- a/lua/diff-review/ui.lua
+++ b/lua/diff-review/ui.lua
@@ -59,6 +59,52 @@ local function set_comment_line_highlight()
   end
 end
 
+-- Blend a color toward a base color by a given factor (0.0 = full color, 1.0 = full base)
+local function blend(color, base, factor)
+  local r1 = math.floor(color / 0x10000)
+  local g1 = math.floor((color % 0x10000) / 0x100)
+  local b1 = color % 0x100
+  local r2 = math.floor(base / 0x10000)
+  local g2 = math.floor((base % 0x10000) / 0x100)
+  local b2 = base % 0x100
+  local r = math.floor(r1 + (r2 - r1) * factor)
+  local g = math.floor(g1 + (g2 - g1) * factor)
+  local b = math.floor(b1 + (b2 - b1) * factor)
+  return r * 0x10000 + g * 0x100 + b
+end
+
+-- Get the normal background color
+local function get_normal_bg()
+  local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = "Normal", link = false })
+  if ok and hl and hl.bg then
+    return hl.bg
+  end
+  return 0x1e1e2e -- fallback dark bg
+end
+
+-- Create subtle diff highlight groups by blending theme colors with the background
+local function define_diff_highlights()
+  local bg = get_normal_bg()
+  local opts = config.get()
+  local blend_factor = opts.diff and opts.diff.highlight_blend or 0.60
+
+  -- Get DiffAdd bg color
+  local ok_add, add_hl = pcall(vim.api.nvim_get_hl, 0, { name = "DiffAdd", link = false })
+  if ok_add and add_hl and add_hl.bg then
+    vim.api.nvim_set_hl(0, "DiffReviewAdd", { bg = blend(add_hl.bg, bg, blend_factor) })
+  else
+    vim.api.nvim_set_hl(0, "DiffReviewAdd", { bg = blend(0x2e7d32, bg, blend_factor) })
+  end
+
+  -- Get DiffDelete bg color
+  local ok_del, del_hl = pcall(vim.api.nvim_get_hl, 0, { name = "DiffDelete", link = false })
+  if ok_del and del_hl and del_hl.bg then
+    vim.api.nvim_set_hl(0, "DiffReviewDelete", { bg = blend(del_hl.bg, bg, blend_factor) })
+  else
+    vim.api.nvim_set_hl(0, "DiffReviewDelete", { bg = blend(0xc62828, bg, blend_factor) })
+  end
+end
+
 -- Initialize UI
 function M.init()
   define_signs()
@@ -78,6 +124,17 @@ function M.init()
 
   -- Define renamed file highlight (cyan-ish)
   vim.api.nvim_set_hl(0, "DiffReviewRenamed", { link = "Function" })
+
+  -- Define subtle diff line highlights
+  define_diff_highlights()
+
+  -- Re-define highlights when colorscheme changes
+  vim.api.nvim_create_autocmd("ColorScheme", {
+    group = vim.api.nvim_create_augroup("DiffReviewHighlights", { clear = true }),
+    callback = function()
+      define_diff_highlights()
+    end,
+  })
 end
 
 -- Clear all comment UI for a buffer


### PR DESCRIPTION
## Summary

- **File navigation**: `gf` opens file in original tab instead of closing review, with split/vsplit support and `gr` to return
- **Review tracking**: Mark files as reviewed with `x`, persisted across sessions, with visual indicators in file list
- **Diff gutter**: Show old/new file line numbers in statuscolumn, hide on metadata lines, no separator borders
- **Hunk separators**: Blank line between hunks for visual clarity
- **Comment fixes**: Restore `<leader>c` binding, prevent note mode from overriding diff keymaps, show file line numbers instead of buffer lines in comments and exports
- **Highlight blending**: Configurable `diff.highlight_blend` option to soften DiffAdd/DiffDelete backgrounds, adapts to colorscheme changes

## Test plan
- [ ] Open a diff review with `DiffReview main`
- [ ] Verify `gf` opens file in original tab, `gr` returns to review
- [ ] Mark files reviewed with `x`, close and reopen to verify persistence
- [ ] Verify gutter shows correct file line numbers
- [ ] Add single and range comments with `<leader>c`, verify file line numbers in display and export
- [ ] Change colorscheme and verify diff highlights update
- [ ] Test `highlight_blend` config option at various values